### PR TITLE
Sanitise Inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/debug": "^4.1.5",
         "@types/ioredis": "^4.19.4",
         "@types/mocha": "^8.2.0",
-        "@types/node": "14.14.28",
+        "@types/node": "^14.14.28",
         "chai": "^4.3.0",
         "delay": "^4.4.1",
         "glob": "^7.1.6",
@@ -694,7 +694,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",

--- a/src/activity/activity.ts
+++ b/src/activity/activity.ts
@@ -102,6 +102,14 @@ export class Activity<ScheduleType extends string> implements Closable {
       );
     }
 
+    if (options.queue) {
+      options.queue = encodeURIComponent(options.queue);
+    }
+
+    if (options.id) {
+      options.id = encodeURIComponent(options.id);
+    }
+
     this.redis.psubscribe(`${options.queue ?? "*"}:${options.id ?? "*"}`);
   }
 
@@ -109,7 +117,7 @@ export class Activity<ScheduleType extends string> implements Closable {
     const [_type, ...args] = splitEvent(message, 9);
     const type = _type as OnActivityEvent["type"];
 
-    const channelParts = channel.split(":");
+    const channelParts = channel.split(":").map(decodeURIComponent);
     if (channelParts.length !== 2) {
       return;
     }

--- a/test/functional/activity.test.ts
+++ b/test/functional/activity.test.ts
@@ -18,22 +18,22 @@ function test(backend: "Redis" | "In-Memory") {
       const currentDate = new Date();
 
       await env.producer.enqueue({
-        queue: "activity-queue",
+        queue: "activity:queue",
         id: "a",
         payload: '{"lol":"lel"}',
         runAt: currentDate,
       });
 
       await env.producer.enqueue({
-        queue: "activity-queue",
-        id: "b",
+        queue: "activity:queue",
+        id: "b;wild",
         payload: "lol",
         runAt: new Date(9999999999999),
         exclusive: true,
       });
 
       await env.producer.enqueue({
-        queue: "activity-queue",
+        queue: "activity:queue",
         id: "repeated",
         payload: "lol",
         runAt: currentDate,
@@ -44,7 +44,7 @@ function test(backend: "Redis" | "In-Memory") {
         },
       });
 
-      await env.producer.delete("activity-queue", "b");
+      await env.producer.delete("activity:queue", "b;wild");
 
       await delay(50);
 
@@ -52,7 +52,7 @@ function test(backend: "Redis" | "In-Memory") {
         {
           type: "scheduled",
           job: {
-            queue: "activity-queue",
+            queue: "activity:queue",
             id: "a",
             payload: '{"lol":"lel"}',
             runAt: currentDate,
@@ -65,8 +65,8 @@ function test(backend: "Redis" | "In-Memory") {
         {
           type: "scheduled",
           job: {
-            queue: "activity-queue",
-            id: "b",
+            queue: "activity:queue",
+            id: "b;wild",
             payload: "lol",
             runAt: new Date(9999999999999),
             count: 1,
@@ -78,7 +78,7 @@ function test(backend: "Redis" | "In-Memory") {
         {
           type: "scheduled",
           job: {
-            queue: "activity-queue",
+            queue: "activity:queue",
             id: "repeated",
             payload: "lol",
             count: 1,
@@ -94,43 +94,43 @@ function test(backend: "Redis" | "In-Memory") {
         },
         {
           type: "deleted",
-          queue: "activity-queue",
-          id: "b",
+          queue: "activity:queue",
+          id: "b;wild",
         },
         {
           type: "requested",
-          queue: "activity-queue",
+          queue: "activity:queue",
           id: "a",
         },
         {
           type: "requested",
-          queue: "activity-queue",
+          queue: "activity:queue",
           id: "repeated",
         },
         {
           type: "acknowledged",
-          queue: "activity-queue",
+          queue: "activity:queue",
           id: "a",
         },
         {
           type: "acknowledged",
-          queue: "activity-queue",
+          queue: "activity:queue",
           id: "repeated",
         },
         {
           type: "rescheduled",
-          queue: "activity-queue",
+          queue: "activity:queue",
           runAt: new Date(+currentDate + 10),
           id: "repeated",
         },
         {
           type: "requested",
-          queue: "activity-queue",
+          queue: "activity:queue",
           id: "repeated",
         },
         {
           type: "acknowledged",
-          queue: "activity-queue",
+          queue: "activity:queue",
           id: "repeated",
         },
       ]);

--- a/test/functional/job-management.test.ts
+++ b/test/functional/job-management.test.ts
@@ -11,14 +11,14 @@ function test(backend: "Redis" | "In-Memory") {
     describe("Producer#scanQueue", () => {
       it("returns pending jobs", async () => {
         const result = await env.producer.enqueue({
-          queue: "producer-scan-queue",
+          queue: "producer;scan;queue",
           id: "a",
           payload: "a",
           runAt: new Date("2020-10-27T07:36:56.321Z"),
         });
 
         expect(result).to.deep.eq({
-          queue: "producer-scan-queue",
+          queue: "producer;scan;queue",
           id: "a",
           payload: "a",
           runAt: new Date("2020-10-27T07:36:56.321Z"),
@@ -29,20 +29,20 @@ function test(backend: "Redis" | "In-Memory") {
         });
 
         await env.producer.enqueue({
-          queue: "producer-scan-queue",
+          queue: "producer;scan;queue",
           id: "b",
           payload: "b",
           runAt: new Date("2020-10-27T07:36:56.321Z"),
         });
 
         const { jobs, newCursor } = await env.producer.scanQueue(
-          "producer-scan-queue",
+          "producer;scan;queue",
           0
         );
 
         expect(jobs).to.have.deep.members([
           {
-            queue: "producer-scan-queue",
+            queue: "producer;scan;queue",
             id: "b",
             payload: "b",
             runAt: new Date("2020-10-27T07:36:56.321Z"),
@@ -52,7 +52,7 @@ function test(backend: "Redis" | "In-Memory") {
             retry: [],
           },
           {
-            queue: "producer-scan-queue",
+            queue: "producer;scan;queue",
             id: "a",
             payload: "a",
             runAt: new Date("2020-10-27T07:36:56.321Z"),


### PR DESCRIPTION
This PR fixes a sincere bug where queues that include ":" would break the Redis key scheme.
It is counter-acted by passing all queues and IDs through "encodeURIComponent".