### PR TITLE
Fix Exclusive Starvation issue

### DIFF
--- a/src/worker/request.lua
+++ b/src/worker/request.lua
@@ -62,11 +62,11 @@ local exclusive = jobData[6]
 local retry = jobData[7]
 
 if exclusive == "true" then
+  redis.call("SADD", KEYS[3], queue)
+
   if redis.call("HGET", KEYS[4], queue) ~= "0" then
     redis.call("ZADD", ARGV[3] .. ":" .. queue, scoreString, id)
     return -1
-  else
-    redis.call("SADD", KEYS[3], queue)
   end
 end
 

--- a/test/functional/support.ts
+++ b/test/functional/support.ts
@@ -86,6 +86,11 @@ export function makeWorkerEnv(
         workerEnv.jobs.push([Date.now(), job]);
         workerEnv.nextExecDates.push(meta.nextExecDate);
 
+        if (job.payload.startsWith("block:")) {
+          const duration = job.payload.split(":")[1];
+          await delay(+duration);
+        }
+
         if (fail(job)) {
           throw new Error("failing!");
         }


### PR DESCRIPTION
Before, exclusive jobs could starve if there were a constant stream of non-exclusive jobs that pushed themselves in-line.

This PR changes the behaviour: Whenever an exclusive job is encountered, it'll block all non-exclusive jobs behind it. That way, it will never starve.

Co-authored-by: Antony Kamp <tony.kamp@web.de>