### PR TITLE
Add opentracing Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
+        "@opentelemetry/api": "^0.20.0",
         "debug": "^4.3.1",
         "ioredis": "^4.27.1",
         "ioredis-mock": "^5.5.6"
@@ -431,6 +432,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.20.0.tgz",
+      "integrity": "sha512-n06MtDYEc2H07S/NTvGMlxF2Ijp0YbNrI/rBgLcxpEh3hxOkPZA12gxlUoZkBHWCZYau2j3b/uL+QFpiQKOjSw==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -3201,6 +3210,11 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@opentelemetry/api": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.20.0.tgz",
+      "integrity": "sha512-n06MtDYEc2H07S/NTvGMlxF2Ijp0YbNrI/rBgLcxpEh3hxOkPZA12gxlUoZkBHWCZYau2j3b/uL+QFpiQKOjSw=="
     },
     "@tsconfig/node10": {
       "version": "1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/api": "^0.20.0",
         "debug": "^4.3.1",
         "ioredis": "^4.27.1",
-        "ioredis-mock": "^5.5.6"
+        "ioredis-mock": "^5.5.6",
+        "opentracing": "^0.14.5"
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
@@ -432,14 +432,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.20.0.tgz",
-      "integrity": "sha512-n06MtDYEc2H07S/NTvGMlxF2Ijp0YbNrI/rBgLcxpEh3hxOkPZA12gxlUoZkBHWCZYau2j3b/uL+QFpiQKOjSw==",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -2006,6 +1998,14 @@
         "wrappy": "1"
       }
     },
+    "node_modules/opentracing": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.5.tgz",
+      "integrity": "sha512-XLKtEfHxqrWyF1fzxznsv78w3csW41ucHnjiKnfzZLD5FN8UBDZZL1i4q0FR29zjxXhm+2Hop+5Vr/b8tKIvEg==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -3210,11 +3210,6 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
-    },
-    "@opentelemetry/api": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.20.0.tgz",
-      "integrity": "sha512-n06MtDYEc2H07S/NTvGMlxF2Ijp0YbNrI/rBgLcxpEh3hxOkPZA12gxlUoZkBHWCZYau2j3b/uL+QFpiQKOjSw=="
     },
     "@tsconfig/node10": {
       "version": "1.0.7",
@@ -4442,6 +4437,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "opentracing": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.5.tgz",
+      "integrity": "sha512-XLKtEfHxqrWyF1fzxznsv78w3csW41ucHnjiKnfzZLD5FN8UBDZZL1i4q0FR29zjxXhm+2Hop+5Vr/b8tKIvEg=="
     },
     "os-tmpdir": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
+    "@opentelemetry/api": "^0.20.0",
     "debug": "^4.3.1",
     "ioredis": "^4.27.1",
     "ioredis-mock": "^5.5.6"

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.20.0",
     "debug": "^4.3.1",
     "ioredis": "^4.27.1",
-    "ioredis-mock": "^5.5.6"
+    "ioredis-mock": "^5.5.6",
+    "opentracing": "^0.14.5"
   }
 }

--- a/src/shared/tracer.ts
+++ b/src/shared/tracer.ts
@@ -1,0 +1,3 @@
+import api from "@opentelemetry/api";
+
+export default api.trace.getTracer("@quirrel/owl");

--- a/src/shared/tracer.ts
+++ b/src/shared/tracer.ts
@@ -1,3 +1,33 @@
-import api from "@opentelemetry/api";
+import opentracing, { Span } from "opentracing";
 
-export default api.trace.getTracer("@quirrel/owl");
+const tracer = opentracing.globalTracer();
+
+export function logError(span: Span, error: any) {
+  span.setTag(opentracing.Tags.ERROR, true)
+  span.logEvent("error", {
+    "error.object": error,
+    message: error.message,
+    stack: error.stack,
+  });
+}
+
+export function wrap<Args extends any[], Result>(
+  name: string,
+  doIt: (span: Span) => (...args: Args) => Promise<Result>
+): (...args: Args) => Promise<Result> {
+  return async (...args) => {
+    tracer.startSpan(name);
+    const span = tracer.startSpan(name);
+    try {
+      const result = await doIt(span)(...args);
+      return result;
+    } catch (error) {
+      logError(span, error);
+      throw error;
+    } finally {
+      span.finish();
+    }
+  };
+}
+
+export default tracer;

--- a/src/shared/tracer.ts
+++ b/src/shared/tracer.ts
@@ -1,8 +1,8 @@
-import opentracing, { Span } from "opentracing";
+import * as opentracing from "opentracing";
 
 const tracer = opentracing.globalTracer();
 
-export function logError(span: Span, error: any) {
+export function logError(span: opentracing.Span, error: any) {
   span.setTag(opentracing.Tags.ERROR, true)
   span.logEvent("error", {
     "error.object": error,
@@ -13,7 +13,7 @@ export function logError(span: Span, error: any) {
 
 export function wrap<Args extends any[], Result>(
   name: string,
-  doIt: (span: Span) => (...args: Args) => Promise<Result>
+  doIt: (span: opentracing.Span) => (...args: Args) => Promise<Result>
 ): (...args: Args) => Promise<Result> {
   return async (...args) => {
     tracer.startSpan(name);

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -13,7 +13,7 @@ import { JobDistributor } from "./job-distributor";
 import { defineLocalCommands } from "../redis-commands";
 import { scanTenants } from "../shared/scan-tenants";
 import * as tracer from "../shared/tracer";
-import opentracing, { Span } from "opentracing";
+import * as opentracing from "opentracing";
 
 declare module "ioredis" {
   interface Commands {
@@ -43,7 +43,7 @@ declare module "ioredis" {
 export type Processor<ScheduleType extends string> = (
   job: Readonly<Job<ScheduleType>>,
   ackDescriptor: AcknowledgementDescriptor,
-  span: Span
+  span: opentracing.Span
 ) => Promise<void>;
 
 function parseTenantFromChannel(topic: string) {


### PR DESCRIPTION
In an effort to extend Datadog tracing to Owl, this PR integrates `opentracing` into Owl. One can then call `opentracing.setGlobalTracer` on Quirrel to have Owl fully configured.
We'll start with instrumenting the `worker` side of Owl, and add more tracing step-by-step.