### PR TITLE
Bugfix: Re-Enqueue repeated jobs if orphaned

### DIFF
--- a/src/activity/activity.ts
+++ b/src/activity/activity.ts
@@ -100,7 +100,7 @@ export class Activity<ScheduleType extends string> implements Closable {
     options: SubscriptionOptions = {}
   ) {
     this.redis = redisFactory();
-    this.producer = new Producer<ScheduleType>(redisFactory);
+    this.producer = new Producer<ScheduleType>(redisFactory, null as any);
 
     this.redis.on("pmessage", (_pattern, channel, message) =>
       this.handleMessage(channel, message)

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export default class Owl<ScheduleType extends string> {
   public createProducer() {
     return new Producer<ScheduleType>(
       this.redisFactory,
+      this.scheduleMap,
       this.onError,
       this.staleCheckerConfig,
       this.logger

--- a/src/producer/producer.ts
+++ b/src/producer/producer.ts
@@ -10,6 +10,7 @@ import {
 } from "../encodeRedisKey";
 import { defineLocalCommands } from "../redis-commands";
 import type { Logger } from "pino";
+import { ScheduleMap } from "..";
 
 declare module "ioredis" {
   interface Commands {
@@ -46,6 +47,7 @@ export class Producer<ScheduleType extends string> implements Closable {
 
   constructor(
     redisFactory: () => Redis,
+    scheduleMap: ScheduleMap<ScheduleType>,
     onError?: OnError<ScheduleType>,
     staleCheckerConfig?: StaleCheckerConfig,
     private readonly logger?: Logger
@@ -64,6 +66,7 @@ export class Producer<ScheduleType extends string> implements Closable {
       this.redis,
       this.acknowledger,
       this,
+      scheduleMap,
       staleCheckerConfig,
       this.logger
     );

--- a/test/util.ts
+++ b/test/util.ts
@@ -7,13 +7,17 @@ export function describeAcrossBackends(
   runTests: (backend: Backend) => void
 ) {
   describe(topic, () => {
-    describe("Redis", () => {
-      runTests("Redis");
-    });
+    if (process.env.TEST_BACKEND !== "In-Memory") {
+      describe("Redis", () => {
+        runTests("Redis");
+      });
+    }
 
-    describe("In-Memory", () => {
-      runTests("In-Memory");
-    });
+    if (process.env.TEST_BACKEND !== "Redis") {
+      describe("In-Memory", () => {
+        runTests("In-Memory");
+      });
+    }
   });
 }
 


### PR DESCRIPTION
There has been a defect where orphaned jobs weren't re-enqueued after being orphaned, affecting e.g. Quirrel Cron jobs. This PR fixes the bug and adds a regression test.