### PR TITLE
Reduce number of timers

### DIFF
--- a/src/worker/job-distributor.test.ts
+++ b/src/worker/job-distributor.test.ts
@@ -26,6 +26,10 @@ function tick() {
   return new Promise(setImmediate);
 }
 
+export function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 describe(JobDistributor.name, () => {
   let closables: Closable[] = [];
   afterEach(async () => {
@@ -116,7 +120,6 @@ describe(JobDistributor.name, () => {
     const log: string[] = [];
 
     let fetchCount = 0;
-    const blocker = makeBlocker();
     const distributor = new JobDistributor(
       async function* () {
         yield [""];
@@ -126,7 +129,7 @@ describe(JobDistributor.name, () => {
 
         switch (fetchCount) {
           case 1:
-            return ["wait", blocker.block("wait")];
+            return ["wait", 10];
           case 2:
             return ["success", "1"];
           default:
@@ -145,7 +148,7 @@ describe(JobDistributor.name, () => {
 
     expect(log).to.eql([]);
 
-    await blocker("wait");
+    await delay(15);
 
     expect(log).to.eql(["work:1"]);
   });

--- a/src/worker/job-distributor.ts
+++ b/src/worker/job-distributor.ts
@@ -18,9 +18,7 @@ export class JobDistributor<T> implements Closable {
     private readonly fetchInitialTenants: () => AsyncGenerator<string[]>,
     private readonly fetch: (
       tenant: string
-    ) => Promise<
-      ["empty"] | ["retry"] | ["success", T] | ["wait", Promise<void>]
-    >,
+    ) => Promise<["empty"] | ["retry"] | ["success", T] | ["wait", number]>,
     private readonly run: (job: T, tenant: string) => Promise<void>,
     private readonly logger?: Logger,
     public readonly maxJobs: number = 100,
@@ -56,21 +54,31 @@ export class JobDistributor<T> implements Closable {
   setTimeout: (cb: () => void, timeout: number) => NodeJS.Timeout =
     global.setTimeout;
 
-  autoCheckIds: Record<string, NodeJS.Timeout> = {};
-
   private delayAutoCheck(tenant: string) {
-    if (this.autoCheckIds[tenant]) {
-      clearTimeout(this.autoCheckIds[tenant]);
+    this.checkAgainAfter(tenant, this.autoCheckEvery);
+  }
+
+  nextChecks: Record<string, { handle: NodeJS.Timeout; time: number }> = {};
+
+  private checkAgainAfter(tenant: string, millis: number) {
+    const date = Date.now() + millis;
+    if (this.nextChecks[tenant]) {
+      const { handle, time } = this.nextChecks[tenant];
+      if (time < date) {
+        return;
+      }
+
+      clearTimeout(handle);
     }
 
     if (this.isClosed) {
       return;
     }
 
-    this.autoCheckIds[tenant] = this.setTimeout(
-      () => this.checkForNewJobs(tenant),
-      this.autoCheckEvery
-    );
+    this.nextChecks[tenant] = {
+      handle: this.setTimeout(() => this.checkForNewJobs(tenant), millis),
+      time: date,
+    };
   }
 
   public async checkForNewJobs(tenant: string) {
@@ -93,8 +101,8 @@ export class JobDistributor<T> implements Closable {
 
         case "wait": {
           const waitFor = result[1];
-          await waitFor;
-          continue;
+          this.checkAgainAfter(tenant, waitFor);
+          return;
         }
 
         case "retry": {
@@ -106,8 +114,8 @@ export class JobDistributor<T> implements Closable {
 
   close() {
     this.isClosed = true;
-    for (const autoCheckId of Object.values(this.autoCheckIds)) {
-      clearTimeout(autoCheckId);
+    for (const { handle } of Object.values(this.nextChecks)) {
+      clearTimeout(handle);
     }
   }
 }

--- a/src/worker/job-distributor.ts
+++ b/src/worker/job-distributor.ts
@@ -76,7 +76,10 @@ export class JobDistributor<T> implements Closable {
     }
 
     this.nextChecks[tenant] = {
-      handle: this.setTimeout(() => this.checkForNewJobs(tenant), millis),
+      handle: this.setTimeout(() => {
+        delete this.nextChecks[tenant];
+        this.checkForNewJobs(tenant);
+      }, millis),
       time: date,
     };
   }

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -171,12 +171,7 @@ export class Worker<ScheduleType extends string> implements Closable {
         } else {
           span.setTag("result", "wait");
           span.setTag("wait-for", timeout);
-          return [
-            "wait",
-            new Promise((resolve) => {
-              setTimeout(resolve, timeout);
-            }),
-          ];
+          return ["wait", timeout];
         }
       }
 
@@ -251,7 +246,10 @@ export class Worker<ScheduleType extends string> implements Closable {
       try {
         await this.processor(job, ackDescriptor, span);
         span.setTag("result", "success");
-        this.logger?.trace({ job, ackDescriptor }, "Worker: Finished execution");
+        this.logger?.trace(
+          { job, ackDescriptor },
+          "Worker: Finished execution"
+        );
       } catch (error) {
         tracer.logError(span, error);
         this.logger?.trace({ job, ackDescriptor }, "Worker: Execution errored");

--- a/test/functional/retry.test.ts
+++ b/test/functional/retry.test.ts
@@ -8,7 +8,6 @@ describeAcrossBackends("Retry", (backend) => {
       return false;
     }
 
-
     throw new Error("failing!");
   });
 
@@ -77,9 +76,19 @@ describeAcrossBackends("Retry", (backend) => {
 
       const executionDates = env.jobs.map(([executionDate]) => executionDate);
       expect(executionDates).to.have.length(4);
-      expect(executionDates[1] - executionDates[0]).to.be.within(5, 20);
-      expect(executionDates[2] - executionDates[0]).to.be.within(80, 120);
-      expect(executionDates[3] - executionDates[0]).to.be.within(180, 220);
+      const firstDuration = executionDates[1] - executionDates[0];
+      const secondDuration = executionDates[2] - executionDates[0];
+      const thirdDuration = executionDates[3] - executionDates[0];
+
+      if (backend === "Redis") {
+        expect(firstDuration).to.be.within(5, 25);
+        expect(secondDuration).to.be.within(80, 120);
+        expect(thirdDuration).to.be.within(180, 220);
+      } else {
+        expect(firstDuration).to.be.within(5, 50);
+        expect(secondDuration).to.be.within(50, 150);
+        expect(thirdDuration).to.be.within(150, 250);
+      }
 
       const counts = env.jobs.map(([, job]) => job.count);
       expect(counts).to.eql([1, 2, 3, 4]);


### PR DESCRIPTION
At the moment, there's a barrage of Peeks fired at a job that's been `wait`-ing before. This PR changes it so there's only a single timer per tenant.