### PR TITLE
queue-level exclusive jobs

### DIFF
--- a/src/Job.ts
+++ b/src/Job.ts
@@ -4,7 +4,6 @@ export interface Job<ScheduleType extends string = string> {
   payload: string;
 
   runAt: Date;
-  exclusive: boolean;
 
   retry: number[];
 
@@ -23,12 +22,6 @@ export interface JobEnqueue<ScheduleType extends string = string> {
   payload: string;
 
   runAt?: Date;
-
-  /**
-   * If set to `true`, no other job on the same queue
-   * will be executed at the same time as this job.
-   */
-  exclusive?: boolean;
 
   /**
    * Override if ID already exists

--- a/src/activity/activity.ts
+++ b/src/activity/activity.ts
@@ -108,7 +108,7 @@ export class Activity<ScheduleType extends string> implements Closable {
   }
 
   private async handleMessage(channel: string, message: string) {
-    const [_type, ...args] = splitEvent(message, 9);
+    const [_type, ...args] = splitEvent(message, 8);
     const type = _type as OnActivityEvent["type"];
 
     const channelParts = channel.split(":").map(decodeRedisKey);
@@ -124,7 +124,6 @@ export class Activity<ScheduleType extends string> implements Closable {
         schedule_type,
         schedule_meta,
         max_times,
-        exclusive,
         count,
         retryJson,
         payload,
@@ -137,7 +136,6 @@ export class Activity<ScheduleType extends string> implements Closable {
           payload,
           runAt: new Date(+runDate),
           count: Number(count),
-          exclusive: exclusive === "true",
           retry: JSON.parse(retryJson),
           schedule: schedule_type
             ? {

--- a/src/producer/producer.ts
+++ b/src/producer/producer.ts
@@ -22,7 +22,6 @@ declare module "ioredis" {
       schedule_meta: string | undefined,
       times: number | undefined,
       overwrite: boolean,
-      exclusive: boolean,
       retryIntervals: string
     ): Promise<0 | 1>;
 
@@ -93,7 +92,6 @@ export class Producer<ScheduleType extends string> implements Closable {
       job.schedule?.meta,
       job.schedule?.times,
       job.override ?? false,
-      job.exclusive ?? false,
       JSON.stringify(retry)
     );
     this.logger?.debug({ job }, "Producer: Enqueued");
@@ -104,7 +102,6 @@ export class Producer<ScheduleType extends string> implements Closable {
       count: 1,
       payload: job.payload,
       runAt: job.runAt,
-      exclusive: job.exclusive ?? false,
       schedule: job.schedule,
       retry,
     };
@@ -199,7 +196,6 @@ export class Producer<ScheduleType extends string> implements Closable {
         schedule_meta,
         count,
         max_times,
-        exclusive,
         retry,
       } = hgetallResult;
 
@@ -215,7 +211,6 @@ export class Producer<ScheduleType extends string> implements Closable {
         queue,
         payload,
         runAt: new Date(runAt),
-        exclusive: exclusive === "true",
         schedule: schedule_type
           ? {
               type: schedule_type,

--- a/src/producer/schedule.lua
+++ b/src/producer/schedule.lua
@@ -8,8 +8,7 @@ local scheduleType = ARGV[5]
 local scheduleMeta = ARGV[6]
 local maximumExecutionTimes = ARGV[7]
 local override = ARGV[8] == "true"
-local exclusive = ARGV[9]
-local retryIntervals = ARGV[10] -- as JSON array
+local retryIntervals = ARGV[9] -- as JSON array
 
 local SCHEDULED = 0
 local ID_ALREADY_EXISTS = 1
@@ -31,7 +30,6 @@ redis.call(
     "schedule_meta", scheduleMeta,
     "max_times", maximumExecutionTimes,
     "count", count,
-    "exclusive", exclusive,
     "retry", retryIntervals
 )
 
@@ -39,7 +37,7 @@ redis.call("SADD", "queues:" .. jobQueue, jobId)
 
 redis.call("ZADD", "queue", scheduledExecutionDate, jobQueue .. ":" .. jobId)
 
-redis.call("PUBLISH", jobQueue .. ":" .. jobId, "scheduled" .. ":" .. scheduledExecutionDate .. ":" .. scheduleType .. ":" .. scheduleMeta .. ":" .. maximumExecutionTimes .. ":" .. exclusive .. ":" .. count .. ":" .. retryIntervals .. ":" .. payload)
+redis.call("PUBLISH", jobQueue .. ":" .. jobId, "scheduled" .. ":" .. scheduledExecutionDate .. ":" .. scheduleType .. ":" .. scheduleMeta .. ":" .. maximumExecutionTimes  .. ":" .. count .. ":" .. retryIntervals .. ":" .. payload)
 redis.call("PUBLISH", "scheduled", jobQueue .. ":" .. jobId)
 
 return SCHEDULED

--- a/src/shared/acknowledger.ts
+++ b/src/shared/acknowledger.ts
@@ -70,7 +70,6 @@ export class Acknowledger<ScheduleType extends string> {
           id: descriptor.jobId,
           queue: descriptor.queueId,
           count: 1,
-          exclusive: false,
           payload: "ERROR: Job couldn't be found",
           retry: [],
           runAt: new Date(0),

--- a/test/functional/activity.test.ts
+++ b/test/functional/activity.test.ts
@@ -33,7 +33,6 @@ describeAcrossBackends("Activity", (backend) => {
       id: "b;wild",
       payload: "lol",
       runAt: new Date(9999999999999),
-      exclusive: true,
     });
 
     await env.producer.enqueue({
@@ -61,7 +60,7 @@ describeAcrossBackends("Activity", (backend) => {
             runAt: currentDate,
             count: 1,
             schedule: undefined,
-            exclusive: false,
+
             retry: [],
           },
         },
@@ -74,7 +73,7 @@ describeAcrossBackends("Activity", (backend) => {
             runAt: new Date(9999999999999),
             count: 1,
             schedule: undefined,
-            exclusive: true,
+
             retry: [],
           },
         },
@@ -86,7 +85,7 @@ describeAcrossBackends("Activity", (backend) => {
             payload: "lol",
             count: 1,
             runAt: currentDate,
-            exclusive: false,
+
             retry: [],
             schedule: {
               type: "every",

--- a/test/functional/job-management.test.ts
+++ b/test/functional/job-management.test.ts
@@ -24,7 +24,6 @@ describeAcrossBackends("Job Management", (backend) => {
         runAt: new Date("2020-10-27T07:36:56.321Z"),
         count: 1,
         schedule: undefined,
-        exclusive: false,
         retry: [],
       });
 
@@ -48,7 +47,6 @@ describeAcrossBackends("Job Management", (backend) => {
           runAt: new Date("2020-10-27T07:36:56.321Z"),
           schedule: undefined,
           count: 1,
-          exclusive: false,
           retry: [],
         },
         {
@@ -58,7 +56,6 @@ describeAcrossBackends("Job Management", (backend) => {
           runAt: new Date("2020-10-27T07:36:56.321Z"),
           schedule: undefined,
           count: 1,
-          exclusive: false,
           retry: [],
         },
       ]);
@@ -93,7 +90,6 @@ describeAcrossBackends("Job Management", (backend) => {
         runAt: new Date("2020-10-27T07:36:56.321Z"),
         schedule: undefined,
         count: 1,
-        exclusive: false,
         retry: [],
       });
     });


### PR DESCRIPTION
At the moment, it's possible to have both exclusive and non-exclusive jobs on the same Queue. In practice, all usecases have either fully-exclusive queues (queues where all jobs are exclusive) or fully non-exclusive queues (queues where no jobs are exclusive). This PR makes some changes to move the concept of being `exclusive` up a layer: It treats any Queue that ends on `exclusive` as being exclusive, thus saving [one Redis call](https://github.com/quirrel-dev/owl/compare/queue-level-exclusive?expand=1#diff-ed9b11e30d63a85701e7dac86c47099905e490814b5a39c314edec2f07606c2fR33).

Notably, this PR is missing:
- [ ] a migration path
- [ ] any decision on wether this change is actually worth it