### PR TITLE
overriding jobs during execution should preserve the overridden schedule

### DIFF
--- a/src/shared/acknowledge.lua
+++ b/src/shared/acknowledge.lua
@@ -7,12 +7,14 @@ local rescheduleFor = ARGV[3]
 
 local jobTableJobKey = "jobs:" .. jobQueue .. ":" .. jobId
 
+local wasOverridenDuringExecution = redis.call("ZSCORE", "queue", jobQueue .. ":" .. jobId) ~= nil
 redis.call("ZREM", "processing", jobQueue .. ":" .. jobId)
 
 redis.call("PUBLISH", jobQueue .. ":" .. jobId, "acknowledged")
 redis.call("PUBLISH", "acknowledged", jobQueue .. ":" .. jobId)
 
-if rescheduleFor == '' then
+if wasOverridenDuringExecution then
+elseif rescheduleFor == '' then
   redis.call("DEL", jobTableJobKey)
   redis.call("SREM", "queues:" .. jobQueue, jobId)
 else

--- a/test/functional/repro-override-during-execution.test.ts
+++ b/test/functional/repro-override-during-execution.test.ts
@@ -1,0 +1,48 @@
+import { expect } from "chai";
+import { makeWorkerEnv } from "./support";
+import { delay, describeAcrossBackends, makeSignal } from "../util";
+
+describeAcrossBackends("Repro: Override during Execution", (backend) => {
+  const executionStarted = makeSignal();
+  const jobWasOverriden = makeSignal();
+  const env = makeWorkerEnv(backend, async (job) => {
+    if (job.payload === "wait") {
+      executionStarted.signal();
+      await jobWasOverriden;
+    }
+
+    return false;
+  });
+  beforeEach(env.setup);
+  afterEach(env.teardown);
+
+  describe("when job is overriden while being executed", () => {
+    it("is executed along the new (overriden) schedule", async () => {
+      const queue = "override-during";
+      const id = "foo";
+      await env.producer.enqueue({
+        queue,
+        id,
+        schedule: { type: "every", meta: "100" },
+        payload: "wait",
+      });
+
+      await executionStarted;
+
+      const newRunAt = new Date(Date.now() + 10000000);
+      await env.producer.enqueue({
+        queue,
+        id,
+        runAt: newRunAt,
+        override: true,
+        payload: "",
+      });
+
+      jobWasOverriden.signal();
+      await delay(10);
+
+      const job = await env.producer.findById(queue, id);
+      expect(+job.runAt).to.equal(+newRunAt);
+    });
+  });
+});

--- a/test/functional/support.ts
+++ b/test/functional/support.ts
@@ -72,7 +72,7 @@ export function makeProducerEnv(
   return env;
 }
 
-type WorkerFailPredicate = (job: Job<string>) => boolean;
+type WorkerFailPredicate = (job: Job<string>) => boolean | Promise<boolean>;
 
 type JobListener = (job: Job<string>) => void;
 
@@ -126,7 +126,7 @@ export function makeWorkerEnv(
           await delay(1);
         }
 
-        if (fail(job)) {
+        if (await fail(job)) {
           await workerEnv.worker.acknowledger.reportFailure(
             ackDescriptor,
             job,


### PR DESCRIPTION
This PR fixes a bug that occurs when a job is overriden during execution. See https://github.com/quirrel-dev/quirrel/issues/739#issuecomment-902042782 for context.